### PR TITLE
後台常見問題管理 

### DIFF
--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -8,6 +8,21 @@ export const instance = axios.create({
   baseURL: config.apiHost2,
 })
 
+// 常見問題相關
+
+// 取得常見問題
+export const getAllFaqs = instance.get('/commonqnas/all')
+
+// 取得特定一筆常見問題
+export const getFaq = (id) => instance.get(`/commonqnas/${id}`)
+
+// 新增常見問題
+export const addFaq = (data) => instance.post('/commonqnas/new', data)
+
+// 編輯常見問題
+export const updateFaq = (id, data) => instance.put(`/commonqnas/${id}`, data)
+
+// 刪除常見問題
 export const deleteFaq = (id) => instance.delete(`/commonqnas/${id}`)
 
 // export default instance

--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -8,6 +8,6 @@ export const instance = axios.create({
   baseURL: config.apiHost2,
 })
 
-export const deleteFaq = (faqID) => instance.delete(`/commonqnas/${faqID}`)
+export const deleteFaq = (id) => instance.delete(`/commonqnas/${id}`)
 
 // export default instance

--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -1,11 +1,13 @@
 import axios from 'axios'
 const config = {
-  apiHost: 'http://localhost:8081',
+  apiHost1: 'http://localhost:8081',
   apiHost2: 'http://184.73.187.145:5000',
 }
 
-const instance = axios.create({
+export const instance = axios.create({
   baseURL: config.apiHost2,
 })
 
-export default instance
+export const deleteFaq = (faqID) => instance.delete(`/commonqnas/${faqID}`)
+
+// export default instance

--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -11,7 +11,8 @@ export const instance = axios.create({
 // 常見問題相關
 
 // 取得常見問題
-export const getAllFaqs = instance.get('/commonqnas/all')
+export const getAllFaqs = (limit) =>
+  instance.get(`/commonqnas/all?size=${limit}`)
 
 // 取得特定一筆常見問題
 export const getFaq = (id) => instance.get(`/commonqnas/${id}`)
@@ -24,5 +25,9 @@ export const updateFaq = (id, data) => instance.put(`/commonqnas/${id}`, data)
 
 // 刪除常見問題
 export const deleteFaq = (id) => instance.delete(`/commonqnas/${id}`)
+
+// 根據參數 page、limit 拿到限定第幾頁且每頁多少篇的文章
+export const getLimitFaq = (page, limit) =>
+  instance.get(`/commonqnas/all?page=${page}&size=${limit}`)
 
 // export default instance

--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -1,0 +1,11 @@
+import axios from 'axios'
+const config = {
+  apiHost: 'http://localhost:8081',
+  apiHost2: 'http://184.73.187.145:5000',
+}
+
+const instance = axios.create({
+  baseURL: config.apiHost2,
+})
+
+export default instance

--- a/src/components/ManageFaqAdd.js
+++ b/src/components/ManageFaqAdd.js
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import styled from 'styled-components'
 import Container from './Container'
 import { Input, Textarea } from './textField'
@@ -5,6 +6,9 @@ import { BackstageTitle } from './heading'
 import { SmallButton } from './buttons'
 import Swal from 'sweetalert2'
 import { MEDIA_QUERY_SM } from '../styles/breakpoints'
+
+// 引入 addFaq 來串接後端的資料
+import { addFaq } from '../WebAPI'
 
 /* 彈窗出現時的遮罩背景 */
 const BackDrop = styled.div`
@@ -116,22 +120,50 @@ const FaqAddButton = styled(SmallButton)`
 
 // 將從父層傳入的 setAddPopUp、closeModal 這些 props 帶入
 export default function ManageFaqPageAdd({ setAddPopUp, closeModal }) {
-  // 當點擊 "新增" 按鈕時，執行 handleAdd
-  const handleAdd = () => {
-    // 1. 更新 addPopUp 的 state 為 false （不顯示設定新密碼的彈窗）
-    setAddPopUp(false)
+  const [newFaqData, setNewFaqData] = useState({
+    question: '',
+    answer: '',
+  })
 
-    // 2. 跳出 "新增成功"的彈窗提示
-    Swal.fire({
-      icon: 'success',
-      title: '新增成功',
-      showConfirmButton: false,
-      timer: 1500,
+  // 當在輸入框內輸入內容時
+  const handleInput = (e) => {
+    const { name, value } = e.target
+    setNewFaqData({
+      ...newFaqData,
+      [name]: value,
     })
+    console.log(newFaqData)
   }
 
   // 當點擊 "取消" 的按鈕時，執行 handleCancelClick
   const handleCancelClick = () => {
+    // 更新 addPopUp 的 state 為 false （不顯示設定新密碼的彈窗）
+    setAddPopUp(false)
+  }
+
+  // 當點擊 "新增" 按鈕時，執行 handleAdd
+  const handleAdd = (e) => {
+    e.preventDefault()
+    // todo： 先驗證輸入值是否為空，若為空值，跳出提示，且不執行任何動作，停在 pop up 視窗
+
+    try {
+      addFaq(newFaqData).then((res) => {
+        console.log(res)
+        if (res.data.success) {
+          // 跳出 "新增成功"的彈窗提示
+          Swal.fire({
+            icon: 'success',
+            title: '新增成功',
+            showConfirmButton: false,
+            timer: 1500,
+          })
+        }
+      })
+    } catch (err) {
+      console.log(err)
+      Swal.fire('請稍候再試一次!', 'error')
+    }
+
     // 更新 addPopUp 的 state 為 false （不顯示設定新密碼的彈窗）
     setAddPopUp(false)
   }
@@ -149,8 +181,17 @@ export default function ManageFaqPageAdd({ setAddPopUp, closeModal }) {
           {/* 新增問答輸入框的整個區塊 */}
           <AddFaq>
             問題
-            <FaqQuestion name="question" placeholder="請輸入問題"></FaqQuestion>
-            回答<FaqAnswer name="answer" placeholder="請輸入回答"></FaqAnswer>
+            <FaqQuestion
+              name="question"
+              placeholder="請輸入問題"
+              onChange={handleInput}
+            ></FaqQuestion>
+            回答
+            <FaqAnswer
+              name="answer"
+              placeholder="請輸入回答"
+              onChange={handleInput}
+            ></FaqAnswer>
           </AddFaq>
 
           {/*所有按鈕操作的整個區塊 */}

--- a/src/components/ManageFaqEdit.js
+++ b/src/components/ManageFaqEdit.js
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import Container from './Container'
 import { Input, Textarea } from './textField'
@@ -5,6 +6,9 @@ import { BackstageTitle } from './heading'
 import { SmallButton } from './buttons'
 import Swal from 'sweetalert2'
 import { MEDIA_QUERY_SM } from '../styles/breakpoints'
+
+// 引入 updateFaq 來串接後端的資料
+import { getFaq, updateFaq } from '../WebAPI'
 
 /* 彈窗出現時的遮罩背景 */
 const BackDrop = styled.div`
@@ -108,20 +112,54 @@ const FaqUpdateButton = styled(SmallButton)`
     margin-left: 0px;
   }
 `
-// 將從父層傳入的 setEditPopUp、closeModal 這些 props 帶入
-export default function ManageFaqPageAdd({ setEditPopUp, closeModal }) {
-  // 當點擊 "更新" 按鈕時，執行 handleEdit
-  const handleEdit = () => {
-    // 1. 更新 editPopUp 的 state 為 false （不顯示設定新密碼的彈窗）
-    setEditPopUp(false)
+// 將從父層傳入的 setEditPopUp、closeModal、faqId 這些 props 帶入
+export default function ManageFaqPageAdd({
+  setEditPopUp,
+  closeModal,
+  item,
+  faqId,
+}) {
+  console.log('item', item)
+  // console.log(faqId)
+  const [updateFaqData, setUpdateFaqData] = useState({
+    question: item.question,
+    answer: item.answer,
+  })
+  console.log('updateFaq', updateFaqData)
 
-    // 2. 跳出 "更新成功"的彈窗提示
-    Swal.fire({
-      icon: 'success',
-      title: '更新成功',
-      showConfirmButton: false,
-      timer: 1500,
+  // 當在輸入框內輸入內容時
+  const handleEditInput = (e) => {
+    const { name, value } = e.target
+
+    setUpdateFaqData({
+      ...updateFaqData,
+      [name]: value,
     })
+  }
+
+  // 當點擊 "更新" 按鈕時，執行 handleEdit
+  const handleEdit = (e) => {
+    e.preventDefault()
+
+    try {
+      updateFaq(faqId, updateFaqData).then((res) => {
+        console.log(res)
+        if (res.data.success) {
+          //跳出 "更新成功"的彈窗提示
+          Swal.fire({
+            icon: 'success',
+            title: '更新成功',
+            showConfirmButton: false,
+            timer: 1500,
+          })
+        }
+      })
+    } catch (err) {
+      console.log(err)
+      Swal.fire('請稍候再試一次!', 'error')
+    }
+    // 更新 editPopUp 的 state 為 false （不顯示設定新密碼的彈窗）
+    setEditPopUp(false)
   }
 
   // 當點擊 "取消" 的按鈕時，執行 handleCancelClick
@@ -146,13 +184,15 @@ export default function ManageFaqPageAdd({ setEditPopUp, closeModal }) {
             <FaqQuestion
               name="question"
               placeholder="請輸入問題"
-              value="aaa"
+              value={updateFaqData.question}
+              onChange={handleEditInput}
             ></FaqQuestion>
             回答
             <FaqAnswer
               name="answer"
               placeholder="請輸入回答"
-              value="bbb"
+              value={updateFaqData.answer}
+              onChange={handleEditInput}
             ></FaqAnswer>
           </EditFaq>
 

--- a/src/pages/FaqPage/FaqPage.js
+++ b/src/pages/FaqPage/FaqPage.js
@@ -5,7 +5,7 @@ import { PageTitle } from '../../components/heading'
 import { SubTitle } from '../../components/heading'
 
 // 引入 axios 來帶後端的資料
-import axios from '../../WebAPI'
+import { instance as axios } from '../../WebAPI'
 
 /* 所有問答內容的整個區塊 */
 const FaqContent = styled.div`

--- a/src/pages/FaqPage/FaqPage.js
+++ b/src/pages/FaqPage/FaqPage.js
@@ -1,24 +1,11 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import Container from '../../components/Container'
 import { PageTitle } from '../../components/heading'
 import { SubTitle } from '../../components/heading'
 
-// 先帶入暫時的資料，之後再串接後端的資料
-const faqQuestions = [
-  {
-    question: '請問如何贈物?',
-    answer: `點擊 "上傳禮物" 後，輸入要贈物的資料，完成後即可等待索物方請求 `,
-    id: 1,
-    isShowed: false,
-  },
-  {
-    question: '請問如何索物?',
-    answer: `選擇想要索物的物品後，點擊 "想要禮物"，輸入資料後等待贈物者的給予 `,
-    id: 2,
-    isShowed: false,
-  },
-]
+// 引入 axios 來帶後端的資料
+import axios from '../../WebAPI'
 
 /* 所有問答內容的整個區塊 */
 const FaqContent = styled.div`
@@ -51,7 +38,18 @@ const FaAnswer = styled.div`
 
 export default function FaqPage() {
   // 設定問答資料 state
-  const [faqData, setFaqData] = useState(faqQuestions)
+  const [faqData, setFaqData] = useState([])
+
+  // 第一次進入頁面時，撈後端資料，並帶入 faqData 的 state
+  useEffect(() => {
+    axios
+      .get('/commonqnas/all')
+      .then((result) => {
+        setFaqData(result.data.allQAs)
+        // console.log(result.data.allQAs)
+      })
+      .catch((err) => console.log(err))
+  }, [])
 
   // 點擊 "問題" 後，執行 handleQuestionClick，更新 faqData 的 state ，
   // 1. 將點擊的這筆問題的 id 與 faqData 資料中每一筆 id 比對，

--- a/src/pages/ManageFaqPage/ManageFaqPage.js
+++ b/src/pages/ManageFaqPage/ManageFaqPage.js
@@ -144,11 +144,11 @@ export default function ManageFaqPage() {
     setEditPopUp(false)
   }
   // 當點擊 "刪除" 按鈕時，執行 handleDeleteQA
-  const handleDeleteQA = async (id) => {
-    console.log(id)
+  const handleDeleteQA = async (faqId) => {
+    console.log(faqId)
     try {
       // 顯示再次確認刪除的彈窗
-      const willDelete = await Swal.fire({
+      await Swal.fire({
         title: '刪除', // 標題
         text: '確定要刪除嗎？', // 內文
         icon: 'warning', // 最上方為警告的 icon
@@ -159,22 +159,13 @@ export default function ManageFaqPage() {
         confirmButtonText: '是的，我要刪除', // 取消按鈕的文字
         reverseButtons: true, // 按鈕的排列順序
         backdrop: true,
+      }).then((result) => {
+        if (result.isConfirmed) {
+          console.log('Yes, I want to delete this item')
+          deleteFaq(faqId)
+          // todo: 解決自動更新，不需重新整理
+        }
       })
-      // 點擊 "是的，我要刪除" 後，執行：
-      if (willDelete) {
-        console.log('Yes, I want to delete this item')
-        const result = await deleteFaq(id)
-        console.log(result)
-        // if (result.status === 200) {
-        //   Swal.fire({
-        //     title: '刪除成功',
-        //     text: '此筆資料已被刪除',
-        //     icon: 'success',
-        //     confirmButtonColor: '#bae8e8',
-        //     confirmButtonText: '完成',
-        //   })
-        // }
-      }
     } catch (err) {
       console.log(err)
       Swal.fire('請稍候再試一次!', 'error')

--- a/src/pages/ManageFaqPage/ManageFaqPage.js
+++ b/src/pages/ManageFaqPage/ManageFaqPage.js
@@ -11,8 +11,9 @@ import Swal from 'sweetalert2'
 import ManageFaqAdd from '../../components/ManageFaqAdd'
 // 引入 ManageFaqEdit 彈窗 component
 import ManageFaqEdit from '../../components/ManageFaqEdit'
-// 引入 axios 來帶後端的資料
-import { instance as axios, deleteFaq } from '../../WebAPI'
+
+// 引入 axios 與 deleteFaq 來串接後端的資料
+import { getAllFaqs, deleteFaq } from '../../WebAPI'
 
 /* 標題 */
 const Title = styled(BackstageTitle)``
@@ -105,9 +106,6 @@ const FaqDeleteButton = styled(DangerSmallButton)`
 
 export default function ManageFaqPage() {
   // 設定問答資料 state
-  // const [manageFaqData, setManageFaqData] = useState(faqQuestions)
-
-  // 設定問答資料 state
   const [manageFaqData, setManageFaqData] = useState([])
 
   // 設定是否顯示新增問答的彈窗的 state，預設 false（不顯示彈窗）
@@ -118,11 +116,10 @@ export default function ManageFaqPage() {
 
   // 第一次進入頁面時，撈後端資料，並帶入 manageFaqData 的 state
   useEffect(() => {
-    axios
-      .get('/commonqnas/all')
-      .then((result) => {
-        setManageFaqData(result.data.allQAs)
-        console.log(result.data.allQAs)
+    getAllFaqs
+      .then((res) => {
+        setManageFaqData(res.data.allQAs)
+        console.log(res.data.allQAs)
       })
       .catch((err) => console.log(err))
   }, [])
@@ -135,8 +132,9 @@ export default function ManageFaqPage() {
 
   // 當點擊 "編輯" 的按鈕時，執行 handleEditFaqClick
   // => 更新 editPopUp 的 state（toggle 彈窗：若原本無顯示，則打開彈窗；若已顯示，則關閉彈窗）
-  const handleEditFaqClick = () => {
+  const handleEditFaqClick = (id) => {
     setEditPopUp(!editPopUp)
+    console.log(id)
   }
 
   const closeModal = () => {
@@ -209,7 +207,7 @@ export default function ManageFaqPage() {
                   <FaqUpdateWrapper>
                     {/* 常見問題右邊："編輯" 按鈕 */}
                     {/* 點擊 "編輯" 的按鈕後，執行 handleEditFaqClick */}
-                    <FaqEditButton onClick={handleEditFaqClick}>
+                    <FaqEditButton onClick={() => handleEditFaqClick(item.id)}>
                       編輯
                     </FaqEditButton>
 
@@ -219,7 +217,9 @@ export default function ManageFaqPage() {
                       <ManageFaqEdit
                         setEditPopUp={setEditPopUp}
                         closeModal={closeModal}
-                      />
+                        item={item}
+                        faqId={item.id}
+                      ></ManageFaqEdit>
                     )}
 
                     {/* 常見問題右邊："刪除" 按鈕 */}
@@ -242,53 +242,3 @@ export default function ManageFaqPage() {
     </>
   )
 }
-
-//   preConfirm: (id) => {
-//     deleteFaq(id)
-//       .then((response) => {
-//         console.log(response)
-//         // if (!response.ok) {
-//         //   throw new Error(response.statusText)
-//         // }
-//         // return response.json()
-//       })
-//       .catch((error) => {
-//         Swal.showValidationMessage(`Request failed: ${error}`)
-//       })
-//   },
-//   allowOutsideClick: () => !Swal.isLoading(),
-// }).then((result) => {
-//   if (result.isConfirmed) {
-//     Swal.fire({
-//       title: '刪除成功',
-//       text: '此筆資料已被刪除',
-//       icon: 'success',
-//       confirmButtonColor: '#bae8e8',
-//       confirmButtonText: '完成',
-//     })
-//   }
-// })
-
-// 顯示再次確認刪除的彈窗
-// Swal.fire({
-//   title: '刪除', // 標題
-//   text: '確定要刪除嗎？', // 內文
-//   icon: 'warning', // 最上方為警告的 icon
-//   showCancelButton: true, // 是否顯示 "取消" 的按鈕
-//   confirmButtonColor: '#e25151', // 確認按鈕的背景色
-//   cancelButtonColor: '#B7B7B7', // 取消按鈕的背景色
-//   cancelButtonText: '不，取消刪除', // 確認按鈕的文字
-//   confirmButtonText: '是的，我要刪除', // 取消按鈕的文字
-//   reverseButtons: true, // 按鈕的排列順序
-// }).then((result) => {
-//   // 點擊 "確認" 後
-//   if (result.isConfirmed) {
-//     Swal.fire({
-//       title: '刪除成功',
-//       text: '此筆資料已被刪除',
-//       icon: 'success',
-//       confirmButtonColor: '#bae8e8',
-//       confirmButtonText: '完成',
-//     })
-//   }
-// })

--- a/src/pages/ManageFaqPage/ManageFaqPage.js
+++ b/src/pages/ManageFaqPage/ManageFaqPage.js
@@ -13,7 +13,9 @@ import ManageFaqAdd from '../../components/ManageFaqAdd'
 import ManageFaqEdit from '../../components/ManageFaqEdit'
 
 // 引入 axios 與 deleteFaq 來串接後端的資料
-import { getAllFaqs, deleteFaq } from '../../WebAPI'
+import { getAllFaqs, deleteFaq, getLimitFaq } from '../../WebAPI'
+
+import { getPages } from '../../utils'
 
 /* 標題 */
 const Title = styled(BackstageTitle)``
@@ -104,6 +106,30 @@ const FaqDeleteButton = styled(DangerSmallButton)`
 //   margin-left: 27px;
 // `
 
+/* "分頁" - 整個元件 */
+const PaginationContainer = styled.ul`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 50px;
+  color: ${(props) => props.theme.secondary_300};
+`
+
+/* "分頁" - 分頁按鈕 */
+const PageButton = styled.li`
+  width: 48px;
+  height: 48px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 16px;
+  cursor: pointer;
+  border: solid 1px ${(props) => props.theme.general_500};
+
+  &:hover {
+    background-color: ${(props) => props.theme.secondary_100};
+  }
+`
 export default function ManageFaqPage() {
   // 設定問答資料 state
   const [manageFaqData, setManageFaqData] = useState([])
@@ -114,12 +140,19 @@ export default function ManageFaqPage() {
   // 設定是否顯示編輯問答的彈窗的 state，預設 false（不顯示彈窗）
   const [editPopUp, setEditPopUp] = useState(false)
 
+  const [pages, setPages] = useState([])
+  const limit = 5
+
   // 第一次進入頁面時，撈後端資料，並帶入 manageFaqData 的 state
   useEffect(() => {
-    getAllFaqs
+    getAllFaqs(limit)
       .then((res) => {
-        setManageFaqData(res.data.allQAs)
-        console.log(res.data.allQAs)
+        let totalPages = res.data.paginate.allPages
+        setPages(getPages(totalPages))
+        // setManageFaqData(res.data.allQAs)
+      })
+      .then((data) => {
+        getLimitFaq(1, limit).then((faqs) => setManageFaqData(faqs.data.allQAs))
       })
       .catch((err) => console.log(err))
   }, [])
@@ -169,6 +202,12 @@ export default function ManageFaqPage() {
       Swal.fire('請稍候再試一次!', 'error')
     }
   }
+
+  // 執行 handlePageClick()
+  const handlePageClick = (page) => {
+    getLimitFaq(page, limit).then((faqs) => setManageFaqData(faqs.data.allQAs))
+  }
+
   return (
     <>
       <Container>
@@ -238,6 +277,17 @@ export default function ManageFaqPage() {
           <FaqCancelButton>取消</FaqCancelButton>
           <FaqSaveButton>儲存</FaqSaveButton>
         </FaqConfirmWrapper> */}
+        {/* 顯示頁數 */}
+        <PaginationContainer>
+          {/* 顯示頁數按鈕 */}
+          {manageFaqData.length > 0 &&
+            pages.map((page) => (
+              // 點擊頁碼按鈕時，執行 handlePageClick()
+              <PageButton key={page} onClick={() => handlePageClick(page)}>
+                {page}
+              </PageButton>
+            ))}
+        </PaginationContainer>
       </Container>
     </>
   )

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,8 @@
+// get pages's array from total page count
+export const getPages = (totalPages) => {
+  let pages = []
+  for (let i = 1; i <= totalPages; i++) {
+    pages.push(i)
+  }
+  return pages
+}


### PR DESCRIPTION
新增的功能：

- [x] 串接後端 API 資料
- [x] 可以新增問答
- [x]  可以刪除問答
- [x] 可以編輯該頁最後一筆問答
- [x]  可以換頁

目前待處理的問題有：

 - [ ]  操作後需重新整理才能呈現更新後的資料 （新增、編輯、刪除）
 - [ ]  不能編輯所選的問答，點擊 “編輯” 按鈕後會跑到該頁最後一個問答