### PR TITLE
TransactionsPage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,7 +57,7 @@ const Home = () => {
         <Route exact path="/portfolio" component={PortfolioPage} />
         <Route path="/portfolio/edit" component={EditPortfolioPage} />
         <Route exact path="/transactions" component={TransactionsPage} />
-        <Route path="/transactions/detail" component={TransactionsDetailPage} />
+        <Route path="/transactions/:id" component={TransactionsDetailPage} />
         <Route path="/faq" component={FaqPage} />
         <Route path="/privacy" component={PrivacyPage} />
         <Route path="/terms" component={TermsPage} />

--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -26,11 +26,16 @@ export const getMe = async () => await instance.get(`/users/me`)
 
 export const logout = async () => await instance.get('/users/logout')
 
+// transaction
+export const getAllTransactions = async (limit) =>
+  instance.get(`/transactions/all?size=${limit}`)
 
-/***************
-   常見問題相關
-***************/
+export const getTransaction = async (id) => instance.get(`/transactions/${id}`)
 
+export const cancelTransaction = async (id) =>
+  instance.put(`/transactions/${id}/cancel`)
+
+// faq
 export const getAllFaqs = (limit) =>
   instance.get(`/commonqnas/all?size=${limit}`)
 

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import { MEDIA_QUERY_SM } from '../../styles/breakpoints'
 import { SmallButton } from '../buttons'
+import { Img, ImgCircleWrapper } from '../img'
 import NavbarSubmenu from './NavbarSubmenu'
 import ClickAwayListener from 'react-click-away-listener'
 import * as GiIcons from 'react-icons/gi'
@@ -57,31 +58,14 @@ const LoginLink = styled(SmallButton)`
   }
 `
 
-const Avatar = styled.div`
-  position: relative;
+const Avatar = styled(ImgCircleWrapper)`
   display: inline-block;
   width: 2.5rem;
   height: 2.5rem;
-  border-radius: 50%;
-  overflow: hidden;
   cursor: pointer;
-  border: solid 0.1rem ${(props) => props.theme.general_200};
   ${MEDIA_QUERY_SM} {
     display: none;
   }
-`
-
-const Img = styled.img`
-  max-height: 100%;
-  max-width: 100%;
-  width: auto;
-  height: auto;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  margin: auto;
 `
 
 const HamburgerIcon = styled(GiIcons.GiHamburgerMenu)`

--- a/src/components/img.js
+++ b/src/components/img.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+
+export const Img = styled.img`
+  max-height: 100%;
+  max-width: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
+`
+
+export const ImgWrapper = styled.div`
+  position: relative;
+  border: solid 1px ${(props) => props.theme.general_200};
+`
+
+export const ImgCircleWrapper = styled(ImgWrapper)`
+  border-radius: 50%;
+  overflow: hidden;
+`

--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
-import { Link } from 'react-router-dom'
 
-export const TextTab = styled(Link)`
+export const TextTab = styled.p`
   font-style: normal;
   font-weight: 500;
   font-size: 1.5rem;

--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -1,0 +1,162 @@
+import { useState, useEffect, useContext } from 'react'
+import AuthContext from '../contexts'
+import { getAllTransactions, cancelTransaction } from '../WebAPI'
+import Swal from 'sweetalert2'
+
+export default function useTransactions() {
+  const { user } = useContext(AuthContext)
+  const [transactions, setTransactions] = useState([])
+
+  const [behaviorFilter, setBehaviorFilter] = useState('give')
+  const [statusFilter, setStatusFilter] = useState('toBeFilled')
+  const [filterTransactions, setFilterTransactions] = useState([])
+
+  const transactionsPerPage = 10
+  const [currentPage, setCurrentPage] = useState(1)
+  const [currentTransactions, setCurrentTransactions] = useState([])
+
+  useEffect(() => {
+    fetchTransactions()
+  }, [])
+
+  useEffect(() => {
+    let filterResult = filterByBehavior(transactions)
+    filterResult = filterByStatus(filterResult)
+    setFilterTransactions(filterResult)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [behaviorFilter, statusFilter, transactions])
+
+  useEffect(() => {
+    const indexOfLastTransaction = currentPage * transactionsPerPage
+    const indexOfFirstTransaction = indexOfLastTransaction - transactionsPerPage
+    setCurrentTransactions(
+      filterTransactions.slice(indexOfFirstTransaction, indexOfLastTransaction)
+    )
+  }, [currentPage, filterTransactions])
+
+  const fetchTransactions = async () => {
+    const { data } = await getAllTransactions(1000)
+    if (data.message === 'No deal submitted yet.') return
+    setTransactions(data.allTransactions)
+  }
+
+  const filterByBehavior = (transactionsData) => {
+    if (transactionsData.length === 0) return []
+    if (behaviorFilter === 'give') {
+      return transactionsData.filter(
+        (transaction) => transaction.owner._id === user._id
+      )
+    }
+    return transactionsData.filter(
+      (transaction) => transaction.dealer._id === user._id
+    )
+  }
+
+  const filterByStatus = (transactionsData) => {
+    if (transactionsData.length === 0) return []
+    switch (statusFilter) {
+      case 'toBeFilled':
+        return transactionsData.filter(
+          (transaction) =>
+            transaction.isFilled === false && transaction.isCanceled === false
+        )
+      case 'toBePaid':
+        return transactionsData.filter(
+          (transaction) =>
+            transaction.isFilled === true &&
+            transaction.isPaid === false &&
+            transaction.isCanceled === false
+        )
+      case 'sending':
+        return transactionsData.filter(
+          (transaction) =>
+            transaction.isPaid === true &&
+            transaction.isCompleted === false &&
+            transaction.isCanceled === false
+        )
+      case 'isCompleted':
+        return transactionsData.filter(
+          (transaction) =>
+            transaction.isCompleted === true && transaction.isCanceled === false
+        )
+      case 'isCanceled':
+        return transactionsData.filter(
+          (transaction) => transaction.isCanceled === true
+        )
+      default:
+        break
+    }
+  }
+
+  const handleChangeBehaviorTab = (behavior) => {
+    if (behavior === 'give') {
+      setBehaviorFilter('give')
+      return
+    }
+    setBehaviorFilter('receive')
+  }
+
+  const handleChangeStatusTab = (status) => {
+    switch (status) {
+      case 'toBeFilled':
+        setStatusFilter('toBeFilled')
+        break
+      case 'toBePaid':
+        setStatusFilter('toBePaid')
+        break
+      case 'sending':
+        setStatusFilter('sending')
+        break
+      case 'isCompleted':
+        setStatusFilter('isCompleted')
+        break
+      case 'isCanceled':
+        setStatusFilter('isCanceled')
+        break
+      default:
+        break
+    }
+  }
+
+  const handleCancelDeal = (id) => {
+    Swal.fire({
+      icon: 'warning',
+      title: '取消交易',
+      text: '確定要取消交易嗎？',
+      showCancelButton: true,
+      confirmButtonColor: '#e25151',
+      cancelButtonColor: '#B7B7B7',
+      cancelButtonText: '繼續交易',
+      confirmButtonText: '確定取消',
+      reverseButtons: true,
+    }).then((result) => {
+      if (result.isConfirmed) {
+        cancelTransaction(id)
+          .then((res) => {
+            if (res.data.message === 'success') {
+              fetchTransactions()
+            }
+          })
+          .catch((err) => {
+            console.log(err)
+            Swal.fire('發生錯誤！')
+          })
+      }
+    })
+  }
+
+  const handleChangePage = (pageNumber) => setCurrentPage(pageNumber)
+
+  return {
+    filterTransactions,
+    currentTransactions,
+    behaviorFilter,
+    handleChangeBehaviorTab,
+    statusFilter,
+    handleChangeStatusTab,
+    handleCancelDeal,
+    transactionsPerPage,
+    currentPage,
+    handleChangePage,
+  }
+}

--- a/src/pages/LoginPage/LoginPage.js
+++ b/src/pages/LoginPage/LoginPage.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import AuthContext from '../../contexts'
 import { login } from '../../WebAPI'
+import { Link } from 'react-router-dom'
 import { useHistory } from 'react-router'
 import styled from 'styled-components'
 import Container from '../../components/Container'
@@ -84,10 +85,10 @@ export default function LoginPage() {
         {(formik) => (
           <Wrapper>
             <TabWrapper>
-              <TextTab to="/login" $isActive="true">
-                登入
+              <TextTab $isActive={true}>登入</TextTab>
+              <TextTab as={Link} to="/register">
+                註冊
               </TextTab>
-              <TextTab to="/register">註冊</TextTab>
             </TabWrapper>
             <Divider />
             <InputWrapper>

--- a/src/pages/RegisterPage/RegisterPage.js
+++ b/src/pages/RegisterPage/RegisterPage.js
@@ -115,10 +115,10 @@ export default function RegisterPage() {
         {(formik) => (
           <Wrapper>
             <TabWrapper>
-              <TextTab to="/login">登入</TextTab>
-              <TextTab to="/register" $isActive="true">
-                註冊
+              <TextTab as={Link} to="/login">
+                登入
               </TextTab>
+              <TextTab $isActive={true}>註冊</TextTab>
             </TabWrapper>
             <Divider />
             <InputWrapper>

--- a/src/pages/TransactionsPage/TransactionsPage.js
+++ b/src/pages/TransactionsPage/TransactionsPage.js
@@ -1,34 +1,35 @@
+import React, { useLayoutEffect, useContext } from 'react'
 import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+import { useHistory } from 'react-router'
 import Container from '../../components/Container'
 import { PageTitle } from '../../components/heading'
 import { TextTab, BorderTab } from '../../components/tabs'
-import {
-  SmallButton,
-  DangerSmallButton,
-  PageButton,
-} from '../../components/buttons'
+import { Img, ImgWrapper, ImgCircleWrapper } from '../../components/img'
+import { SmallButton, DangerSmallButton } from '../../components/buttons'
+import Pagination from '../../components/Pagination/Pagination'
 import { MEDIA_QUERY_SM, MEDIA_QUERY_MD } from '../../styles/breakpoints'
+import AuthContext from '../../contexts'
+import useTransactions from '../../hooks/useTransactions'
 
-// 引入 sweetalert2 彈窗套件
-import Swal from 'sweetalert2'
-
-const ActionTabsWrapper = styled.div`
+const BehaviorTabsWrapper = styled.div`
   margin: 3rem 0 2rem;
   display: flex;
   justify-content: center;
   text-align: center;
 `
-const ActionTab = styled(TextTab)`
+
+const BehaviorTab = styled(TextTab)`
   font-size: 1.5rem;
   text-align: center;
   margin: 0 2rem;
   width: 3.5rem;
 `
 
-const RecordsWrapper = styled.div`
+const Transactions = styled.div`
   border: ${(props) => props.theme.general_300} solid 1px;
   border-top: 0px;
-  padding: 2rem 8% 3rem;
+  padding: 2rem 8% 0;
   min-height: 50vh;
 `
 
@@ -43,29 +44,106 @@ const StatusTab = styled(BorderTab)`
   overflow: auto;
 `
 
-const Record = styled.div`
+const Transaction = styled.div`
   :not(:first-child) {
     border-top: ${(props) => props.theme.general_500} solid 1px;
   }
   padding: 2rem 0;
+  &:last-of-type {
+    margin-bottom: 3rem;
+  }
 `
 
 const User = styled.p`
-  display: block;
-  margin-bottom: 1rem;
+  display: flex;
+  margin-bottom: 0.75rem;
+`
+
+const Avatar = styled(ImgCircleWrapper)`
+  position: relative;
+  display: inline-block;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+`
+
+const Email = styled.p`
+  margin-left: 0.5rem;
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 `
 
-const ContentWrapper = styled.div`
+const Nickname = styled.span`
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
+
+const ContentAndButtons = styled.div`
   display: flex;
   justify-content: space-between;
-  box-sizing: content-box;
-  flex-wrap: wrap;
   ${MEDIA_QUERY_MD} {
-    flex-direction: row-reverse;
+    display: block;
+  }
+`
+
+const Content = styled.div`
+  display: flex;
+  overflow: auto;
+  ${MEDIA_QUERY_SM} {
+    flex-direction: column;
+  }
+`
+
+const PostImg = styled(ImgWrapper)`
+  min-width: 7rem;
+  min-height: 7rem;
+  margin-right: 2rem;
+  ${MEDIA_QUERY_MD} {
+    position: relative;
+    left: 0;
+  }
+  ${MEDIA_QUERY_SM} {
+    max-width: 7rem;
+    max-height: 7rem;
+    margin: 0 auto 1rem;
+  }
+`
+
+const Detail = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`
+
+const ItemName = styled.p`
+  line-height: 1.5;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 33rem;
+  ${MEDIA_QUERY_MD} {
+    max-width: none;
+  }
+`
+
+const Quantity = styled(ItemName)``
+
+const TradeMode = styled(ItemName)``
+
+const Number = styled(ItemName)``
+
+const Buttons = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin-left: 2rem;
+  ${MEDIA_QUERY_MD} {
+    margin: 1rem 0 0;
+    width: 100%;
+    flex-direction: row;
   }
   ${MEDIA_QUERY_SM} {
     flex-direction: column;
@@ -73,175 +151,181 @@ const ContentWrapper = styled.div`
   }
 `
 
-const ImgWrapper = styled.div`
-  width: 10rem;
-  height: 7rem;
-  margin-right: 2rem;
-  position: relative;
+const TransactionsDetailLink = styled(SmallButton)`
   ${MEDIA_QUERY_MD} {
-    margin: 0;
-  }
-`
-
-const Img = styled.img`
-  max-height: 100%;
-  max-width: 100%;
-  width: auto;
-  height: auto;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  margin: auto;
-`
-
-const TextWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  width: 30rem;
-  ${MEDIA_QUERY_MD} {
-    width: 22rem;
-  }
-  ${MEDIA_QUERY_SM} {
-    margin-top: 1.8rem;
     width: 100%;
-    height: 7.5rem;
-  }
-`
-
-const Tag = styled.p`
-  background: ${(props) => props.theme.primary_300};
-  color: ${(props) => props.theme.general_000};
-  width: 6.5rem;
-  padding: 0.4rem;
-  border-radius: 1rem;
-  text-align: center;
-  ${MEDIA_QUERY_SM} {
-    margin: 0 auto;
-  }
-`
-
-const Detail = styled.p`
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  ${MEDIA_QUERY_SM} {
-    text-align: center;
-  }
-`
-
-const ButtonsWrapper = styled.div`
-  ${MEDIA_QUERY_MD} {
-    display: flex;
-    margin: 1.8rem auto 0rem;
-  }
-  ${MEDIA_QUERY_SM} {
-    display: block;
-  }
-`
-
-const Button = styled(SmallButton)`
-  margin-bottom: 2.5rem;
-  ${MEDIA_QUERY_MD} {
-    width: 8rem;
-    margin-bottom: 0rem;
-    margin-right: 6rem;
+    margin: 0 1rem;
   }
   ${MEDIA_QUERY_SM} {
     width: 100%;
+    max-width: 19rem;
     margin-bottom: 1rem;
   }
 `
 
-const DangerButton = styled(DangerSmallButton)`
+const CancelDealBtn = styled(DangerSmallButton)`
   ${MEDIA_QUERY_MD} {
-    width: 8rem;
+    width: 100%;
+    margin: 0 1rem;
   }
   ${MEDIA_QUERY_SM} {
     width: 100%;
+    max-width: 19rem;
+    margin: 0;
   }
-`
-
-const PaginationWrapper = styled.ul`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  margin-top: 4.5rem;
 `
 
 export default function TransactionsPage() {
-  // 當點擊 "取消交易" 的按鈕時，執行 handleCancel
-  const handleCancel = () => {
-    // 顯示再次確認刪除的彈窗
-    Swal.fire({
-      title: '取消交易', // 標題
-      text: '確定要取消交易嗎？', // 內文
-      icon: 'warning', // 最上方為警告的 icon
-      showCancelButton: true, // 是否顯示 "取消" 的按鈕
-      confirmButtonColor: '#e25151', // 確認按鈕的背景色
-      cancelButtonColor: '#B7B7B7', // 取消按鈕的背景色
-      cancelButtonText: '不，我要繼續交易', // 確認按鈕的文字
-      confirmButtonText: '是的，我要取消', // 取消按鈕的文字
-      reverseButtons: true, // 按鈕的排列順序
-    }).then((result) => {
-      // 點擊 "確認" 後
-      if (result.isConfirmed) {
-        Swal.fire({
-          title: '取消成功',
-          text: '此筆交易已被取消',
-          icon: 'success',
-          confirmButtonColor: '#FFD803',
-          confirmButtonText: '完成',
-        })
-      }
-    })
-  }
+  const { user } = useContext(AuthContext)
+  const history = useHistory()
+
+  useLayoutEffect(() => {
+    if (!user) history.push('/')
+  })
+
+  const {
+    filterTransactions,
+    currentTransactions,
+    behaviorFilter,
+    handleChangeBehaviorTab,
+    statusFilter,
+    handleChangeStatusTab,
+    handleCancelDeal,
+    transactionsPerPage,
+    currentPage,
+    handleChangePage,
+  } = useTransactions()
+
   return (
     <Container>
       <PageTitle>交易紀錄</PageTitle>
-      <ActionTabsWrapper>
-        <ActionTab to="/transactions" $isActive="true">
+      <BehaviorTabsWrapper>
+        <BehaviorTab
+          onClick={() => {
+            handleChangeBehaviorTab('give')
+          }}
+          $isActive={behaviorFilter === 'give' ? true : false}
+        >
           贈物
-        </ActionTab>
-        <ActionTab to="/transactions">索物 </ActionTab>
-      </ActionTabsWrapper>
+        </BehaviorTab>
+        <BehaviorTab
+          onClick={() => {
+            handleChangeBehaviorTab('receive')
+          }}
+          $isActive={behaviorFilter === 'receive' ? true : false}
+        >
+          索物
+        </BehaviorTab>
+      </BehaviorTabsWrapper>
       <StatusTabsWrapper>
-        <StatusTab>刊登中（0）</StatusTab>
-        <StatusTab>索取中（0）</StatusTab>
-        <StatusTab>付運費中（0）</StatusTab>
-        <StatusTab $isActive="true">寄送中（0）</StatusTab>
-        <StatusTab>完成（0）</StatusTab>
+        <StatusTab
+          onClick={() => {
+            handleChangeStatusTab('toBeFilled')
+          }}
+          $isActive={statusFilter === 'toBeFilled' ? true : false}
+        >
+          待填資料
+        </StatusTab>
+        <StatusTab
+          onClick={() => {
+            handleChangeStatusTab('toBePaid')
+          }}
+          $isActive={statusFilter === 'toBePaid' ? true : false}
+        >
+          待付運費
+        </StatusTab>
+        <StatusTab
+          onClick={() => {
+            handleChangeStatusTab('sending')
+          }}
+          $isActive={statusFilter === 'sending' ? true : false}
+        >
+          交貨中
+        </StatusTab>
+        <StatusTab
+          onClick={() => {
+            handleChangeStatusTab('isCompleted')
+          }}
+          $isActive={statusFilter === 'isCompleted' ? true : false}
+        >
+          已完成
+        </StatusTab>
+        <StatusTab
+          onClick={() => {
+            handleChangeStatusTab('isCanceled')
+          }}
+          $isActive={statusFilter === 'isCanceled' ? true : false}
+        >
+          已取消
+        </StatusTab>
       </StatusTabsWrapper>
-      <RecordsWrapper>
-        <Record>
-          <User>暱稱</User>
-          <ContentWrapper>
-            <ImgWrapper>
-              <Img src={`https://source.unsplash.com/random/1`} />
-            </ImgWrapper>
-            <TextWrapper>
-              <Tag>刊登者付費</Tag>
-              <Detail>物品名稱</Detail>
-              <Detail>總數：1 個</Detail>
-              <Detail>已送出：1 個</Detail>
-            </TextWrapper>
-            <ButtonsWrapper>
-              <Button>交易詳情</Button>
-
-              {/* 點擊 "取消交易" 的按鈕後，執行 handleCancel */}
-              <DangerButton onClick={handleCancel}>取消交易</DangerButton>
-            </ButtonsWrapper>
-          </ContentWrapper>
-        </Record>
-        <PaginationWrapper>
-          <PageButton>&lt;</PageButton>
-          <PageButton>1</PageButton>
-          <PageButton>2</PageButton>
-          <PageButton>&gt;</PageButton>
-        </PaginationWrapper>
-      </RecordsWrapper>
+      <Transactions>
+        {currentTransactions.map((transaction) => {
+          return (
+            <Transaction key={transaction.id}>
+              <User>
+                <Avatar>
+                  <Img
+                    src={
+                      behaviorFilter === 'give'
+                        ? transaction.dealer.avatarUrl
+                        : transaction.owner.avatarUrl
+                    }
+                  />
+                </Avatar>
+                <Email>
+                  {behaviorFilter === 'give'
+                    ? transaction.dealer.email
+                    : transaction.owner.email}
+                </Email>
+                <Nickname>
+                  {behaviorFilter === 'give'
+                    ? transaction.dealer.nickname &&
+                      `（${transaction.dealer.nickname}）`
+                    : transaction.owner.nickname &&
+                      `（${transaction.owner.nickname}）`}
+                </Nickname>
+              </User>
+              <ContentAndButtons>
+                <Content>
+                  <PostImg>
+                    <Img src={transaction.post.imgUrls[0]} />
+                  </PostImg>
+                  <Detail>
+                    <ItemName>{transaction.post.itemName}</ItemName>
+                    <Quantity>數量：1</Quantity>
+                    <TradeMode>
+                      交易方式：{transaction.dealMethod.faceToFace && '面交'}
+                    </TradeMode>
+                    <Number>交易編號：{transaction.id}</Number>
+                  </Detail>
+                </Content>
+                <Buttons>
+                  <TransactionsDetailLink
+                    as={Link}
+                    to={`/transactions/${transaction.id}`}
+                  >
+                    交易詳情
+                  </TransactionsDetailLink>
+                  {statusFilter === 'toBeFilled' && (
+                    <CancelDealBtn
+                      onClick={() => handleCancelDeal(transaction.id)}
+                    >
+                      取消交易
+                    </CancelDealBtn>
+                  )}
+                </Buttons>
+              </ContentAndButtons>
+            </Transaction>
+          )
+        })}
+        <Pagination
+          dataPerPage={transactionsPerPage}
+          totalData={filterTransactions.length}
+          handleChangePage={handleChangePage}
+          currentPage={currentPage}
+        />
+      </Transactions>
     </Container>
   )
 }


### PR DESCRIPTION
- 修改交易詳情頁的路徑
- 將 TextTab 從 `Link` 改成 `p`，進一步修改有使用到的頁面，包含登入頁、註冊頁
- 新增 compontent `img.js` ，將它套用到 Navbar 的大頭照上
- 新增交易相關的 API
- 將 transaction 資料帶入交易紀錄頁，完成該頁面的功能