### PR TITLE
Fix manageFaqPage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -54,8 +54,8 @@ const Home = () => {
       <ScrollToTop />
       <Switch>
         <Route exact path="/" component={HomePage} />
-        <Route path="/login" component={LoginPage} />
-        <Route path="/register" component={RegisterPage} />
+        {!user && <Route path="/login" component={LoginPage} />}
+        {!user && <Route path="/register" component={RegisterPage} />}
         <Route path="/about" component={AboutPage} />
         <Route exact path="/givings" component={GivingsPage} />
         {user && <Route path="/givings/add" component={AddGiftPage} />}

--- a/src/components/ManageFaqAdd.js
+++ b/src/components/ManageFaqAdd.js
@@ -1,11 +1,8 @@
-import { useState } from 'react'
 import styled from 'styled-components'
-import { Input, Textarea } from './textField'
+import { InputLabel, Input, Textarea } from './textField'
 import { BackstageTitle } from './heading'
 import { SmallButton } from './buttons'
-import Swal from 'sweetalert2'
 import { MEDIA_QUERY_SM } from '../styles/breakpoints'
-import { addFaq } from '../WebAPI'
 
 export const BackDrop = styled.div`
   width: 100%;
@@ -54,7 +51,6 @@ export const AddFaq = styled.form`
 
 export const QuestionInput = styled(Input)`
   width: 100%;
-  margin-bottom: 50px;
 `
 
 export const AnswerInput = styled(Textarea)`
@@ -99,68 +95,27 @@ export default function ManageFaqPageAdd({
   setFaqs,
   faqs,
   handleToggleAddPopUp,
+  handleInput,
+  handleAddFaq,
 }) {
-  const [newFaqData, setNewFaqData] = useState({
-    question: '',
-    answer: '',
-  })
-
-  const handleInput = (e) => {
-    const { name, value } = e.target
-    setNewFaqData({
-      ...newFaqData,
-      [name]: value,
-    })
-  }
-
-  const handleAddFaq = (e) => {
-    e.preventDefault()
-    addFaq(newFaqData)
-      .then((res) => {
-        const newFaq = res.data.new
-        console.log(res.data)
-        if (res.data.message === 'success') {
-          Swal.fire({
-            icon: 'success',
-            title: '新增成功',
-            showConfirmButton: false,
-            timer: 1500,
-          })
-          setFaqs([
-            {
-              id: newFaq.id,
-              question: newFaq.question,
-              answer: newFaq.answer,
-            },
-            ...faqs,
-          ])
-        }
-      })
-      .catch((err) => {
-        console.log(err)
-        Swal.fire('發生錯誤！')
-      })
-    handleToggleAddPopUp()
-  }
-
   return (
     <>
-      <BackDrop onClick={handleToggleAddPopUp}></BackDrop>
+      <BackDrop onClick={handleToggleAddPopUp} />
       <AddFaqWrapper>
         <Title>新增常見問題</Title>
         <AddFaq>
-          問題
+          <InputLabel>問題</InputLabel>
           <QuestionInput
             name="question"
             placeholder="請輸入問題"
             onChange={handleInput}
-          ></QuestionInput>
-          回答
+          />
+          <InputLabel>回答</InputLabel>
           <AnswerInput
             name="answer"
             placeholder="請輸入回答"
             onChange={handleInput}
-          ></AnswerInput>
+          />
         </AddFaq>
         <ConfirmButtonsWrapper>
           <CancelButton onClick={handleToggleAddPopUp}>取消</CancelButton>

--- a/src/components/ManageFaqEdit.js
+++ b/src/components/ManageFaqEdit.js
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import styled from 'styled-components'
 import {
   BackDrop,
@@ -11,8 +10,7 @@ import {
   CancelButton,
   AddButton,
 } from './ManageFaqAdd'
-import Swal from 'sweetalert2'
-import { updateFaq } from '../WebAPI'
+import { InputLabel } from './textField'
 
 const EditFaqWrapper = styled(AddFaqWrapper)``
 
@@ -25,72 +23,30 @@ export default function ManageFaqEdit({
   setFaqs,
   faqs,
   handleToggleEditPopUp,
+  updateFaqData,
+  handleEditInput,
+  handleUpdateFaq,
 }) {
-  const [updateFaqData, setUpdateFaqData] = useState({
-    question: editedFaq.question,
-    answer: editedFaq.answer,
-  })
-
-  const handleEditInput = (e) => {
-    const { name, value } = e.target
-
-    setUpdateFaqData({
-      ...updateFaqData,
-      [name]: value,
-    })
-  }
-
-  const handleUpdateFaq = (e) => {
-    e.preventDefault()
-    updateFaq(editedFaq.id, updateFaqData)
-      .then((res) => {
-        const newFaq = res.data.update
-        if (res.data.message === 'success') {
-          Swal.fire({
-            icon: 'success',
-            title: '更新成功',
-            showConfirmButton: false,
-            timer: 1500,
-          })
-          setFaqs(
-            faqs.map((faq) => {
-              if (faq.id !== newFaq.id) return faq
-              return {
-                ...faq,
-                question: newFaq.question,
-                answer: newFaq.answer,
-              }
-            })
-          )
-        }
-      })
-      .catch((err) => {
-        console.log(err)
-        Swal.fire('發生錯誤！')
-      })
-    handleToggleEditPopUp()
-  }
-
   return (
     <>
-      <BackDrop onClick={handleToggleEditPopUp}></BackDrop>
+      <BackDrop onClick={handleToggleEditPopUp} />
       <EditFaqWrapper>
         <Title>編輯常見問題</Title>
         <EditFaq>
-          問題
+          <InputLabel>問題</InputLabel>
           <QuestionInput
             name="question"
             placeholder="請輸入問題"
             value={updateFaqData.question}
             onChange={handleEditInput}
-          ></QuestionInput>
-          回答
+          />
+          <InputLabel>回答</InputLabel>
           <AnswerInput
             name="answer"
             placeholder="請輸入回答"
             value={updateFaqData.answer}
             onChange={handleEditInput}
-          ></AnswerInput>
+          />
         </EditFaq>
         <ConfirmButtonsWrapper>
           <CancelButton onClick={handleToggleEditPopUp}>取消</CancelButton>

--- a/src/hooks/useFaqs.js
+++ b/src/hooks/useFaqs.js
@@ -1,14 +1,23 @@
 import { useState, useEffect } from 'react'
 import Swal from 'sweetalert2'
-import { getAllFaqs, deleteFaq } from '../WebAPI'
+import { getAllFaqs, addFaq, updateFaq, deleteFaq } from '../WebAPI'
 
 export default function useFaqs() {
   const [faqs, setFaqs] = useState([])
+  const [currentFaqs, setCurrentFaqs] = useState([])
   const [currentPage, setCurrentPage] = useState(1)
-  const faqsPerPage = 5
+  const faqsPerPage = 10
   const [addPopUp, setAddPopUp] = useState(false)
   const [editPopUp, setEditPopUp] = useState(false)
   const [editedFaq, setEditedFaq] = useState()
+  const [newFaqData, setNewFaqData] = useState({
+    question: '',
+    answer: '',
+  })
+  const [updateFaqData, setUpdateFaqData] = useState({
+    question: '',
+    answer: '',
+  })
 
   useEffect(() => {
     const fetchFaqs = async () => {
@@ -19,10 +28,24 @@ export default function useFaqs() {
     fetchFaqs()
   }, [])
 
-  // Get current faqs
-  const indexOfLastFaq = currentPage * faqsPerPage
-  const indexOfFirstFaq = indexOfLastFaq - faqsPerPage
-  const currentFaqs = faqs.slice(indexOfFirstFaq, indexOfLastFaq)
+  useEffect(() => {
+    window.scrollTo(0, 0)
+    const indexOfLastFaq = currentPage * faqsPerPage
+    const indexOfFirstFaq = indexOfLastFaq - faqsPerPage
+    setCurrentFaqs(faqs.slice(indexOfFirstFaq, indexOfLastFaq))
+  }, [currentPage, faqs])
+
+  useEffect(() => {
+    if (currentFaqs.length === 0) setCurrentPage(1)
+  }, [currentFaqs])
+
+  useEffect(() => {
+    if (editedFaq)
+      setUpdateFaqData({
+        question: editedFaq.question,
+        answer: editedFaq.answer,
+      })
+  }, [editedFaq])
 
   const handleToggleAddPopUp = () => {
     setAddPopUp(!addPopUp)
@@ -31,6 +54,73 @@ export default function useFaqs() {
   const handleToggleEditPopUp = (id, question, answer) => {
     setEditPopUp(!editPopUp)
     setEditedFaq({ id, question, answer })
+  }
+
+  const handleInput = (e) => {
+    const { name, value } = e.target
+    setNewFaqData({
+      ...newFaqData,
+      [name]: value,
+    })
+  }
+
+  const handleAddFaq = (e) => {
+    e.preventDefault()
+    addFaq(newFaqData).then((res) => {
+      const newFaq = res.data.new
+      if (res.data.message === 'success') {
+        Swal.fire({
+          icon: 'success',
+          title: '新增成功',
+          showConfirmButton: false,
+          timer: 1500,
+        })
+        setFaqs([
+          ...faqs,
+          {
+            id: newFaq.id,
+            question: newFaq.question,
+            answer: newFaq.answer,
+          },
+        ])
+        setCurrentPage(Math.ceil((faqs.length + 1) / faqsPerPage))
+      }
+    })
+    handleToggleAddPopUp()
+  }
+
+  const handleEditInput = (e) => {
+    const { name, value } = e.target
+    setUpdateFaqData({
+      ...updateFaqData,
+      [name]: value,
+    })
+  }
+
+  const handleUpdateFaq = (e) => {
+    e.preventDefault()
+    updateFaq(editedFaq.id, updateFaqData).then((res) => {
+      const newFaq = res.data.update
+      if (res.data.message === 'success') {
+        Swal.fire({
+          icon: 'success',
+          title: '更新成功',
+          showConfirmButton: false,
+          timer: 1500,
+        })
+        setFaqs(
+          faqs.map((faq) => {
+            if (faq.id !== newFaq.id) return faq
+            return {
+              ...faq,
+              question: newFaq.question,
+              answer: newFaq.answer,
+            }
+          })
+        )
+      }
+    })
+    handleToggleEditPopUp()
   }
 
   const handleDeleteFaq = (id) => {
@@ -47,22 +137,17 @@ export default function useFaqs() {
       backdrop: true,
     }).then((result) => {
       if (result.isConfirmed) {
-        deleteFaq(id)
-          .then((res) => {
-            if (res.data.message === 'success') {
-              setFaqs(faqs.filter((faq) => faq.id !== id))
-              Swal.fire({
-                icon: 'success',
-                title: '刪除成功',
-                showConfirmButton: false,
-                timer: 1500,
-              })
-            }
-          })
-          .catch((err) => {
-            console.log(err)
-            Swal.fire('發生錯誤！')
-          })
+        deleteFaq(id).then((res) => {
+          if (res.data.message === 'success') {
+            setFaqs(faqs.filter((faq) => faq.id !== id))
+            Swal.fire({
+              icon: 'success',
+              title: '刪除成功',
+              showConfirmButton: false,
+              timer: 1500,
+            })
+          }
+        })
       }
     })
   }
@@ -75,9 +160,14 @@ export default function useFaqs() {
     currentFaqs,
     addPopUp,
     handleToggleAddPopUp,
+    handleInput,
+    handleAddFaq,
     editPopUp,
     editedFaq,
     handleToggleEditPopUp,
+    updateFaqData,
+    handleEditInput,
+    handleUpdateFaq,
     handleDeleteFaq,
     faqsPerPage,
     currentPage,

--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -27,13 +27,10 @@ export default function useTransactions() {
 
   const fetchTransactions = useCallback(() => {
     const fetchingTransactions = async () => {
-      const { data } = await getAllTransactions(1000)
-      if (data.error) {
-        Swal.fire('發生錯誤！')
-        return
-      }
-      if (data.message === 'No deal submitted yet.') return
-      setTransactions(data.allTransactions)
+      const {
+        data: { allTransactions },
+      } = await getAllTransactions(1000)
+      if (allTransactions) setTransactions(allTransactions)
     }
 
     fetchingTransactions()

--- a/src/pages/ManageFaqPage/ManageFaqPage.js
+++ b/src/pages/ManageFaqPage/ManageFaqPage.js
@@ -83,9 +83,14 @@ export default function ManageFaqPage() {
     currentFaqs,
     addPopUp,
     handleToggleAddPopUp,
+    handleInput,
+    handleAddFaq,
     editPopUp,
     editedFaq,
     handleToggleEditPopUp,
+    updateFaqData,
+    handleEditInput,
+    handleUpdateFaq,
     handleDeleteFaq,
     faqsPerPage,
     currentPage,
@@ -96,13 +101,6 @@ export default function ManageFaqPage() {
     <Container>
       <Title>常見問題管理</Title>
       <AddNewFaqButton onClick={handleToggleAddPopUp}>新增問答</AddNewFaqButton>
-      {addPopUp && (
-        <ManageFaqAdd
-          setFaqs={setFaqs}
-          faqs={faqs}
-          handleToggleAddPopUp={handleToggleAddPopUp}
-        />
-      )}
       <FaqWrapper>
         {currentFaqs.map((faq) => {
           return (
@@ -126,12 +124,24 @@ export default function ManageFaqPage() {
             </FaqContent>
           )
         })}
+        {addPopUp && (
+          <ManageFaqAdd
+            setFaqs={setFaqs}
+            faqs={faqs}
+            handleToggleAddPopUp={handleToggleAddPopUp}
+            handleInput={handleInput}
+            handleAddFaq={handleAddFaq}
+          />
+        )}
         {editPopUp && (
           <ManageFaqEdit
             editedFaq={editedFaq}
             setFaqs={setFaqs}
             faqs={faqs}
             handleToggleEditPopUp={handleToggleEditPopUp}
+            updateFaqData={updateFaqData}
+            handleEditInput={handleEditInput}
+            handleUpdateFaq={handleUpdateFaq}
           />
         )}
       </FaqWrapper>

--- a/src/pages/PortfolioPage/UserInfo.js
+++ b/src/pages/PortfolioPage/UserInfo.js
@@ -128,7 +128,9 @@ const EditButton = styled(SmallButton)`
 const UserInfo = ({ userData }) => {
   const { faceToFace, sevenEleven, familyMart } = shippingMethod
   const { user } = useContext(AuthContext)
-  const preferDealMethods = user.preferDealMethods
+  let preferDealMethods = []
+  if (user.preferDealMethods && user.preferDealMethods.selectedMethods)
+    preferDealMethods = user.preferDealMethods.selectedMethods
 
   return (
     <Wrapper>
@@ -149,24 +151,22 @@ const UserInfo = ({ userData }) => {
             <PreferTradeMode>偏好交易方式</PreferTradeMode>
             <TransactionType
               $isSelected={
-                preferDealMethods &&
-                preferDealMethods.convenientStores &&
-                preferDealMethods.convenientStores.includes('全家')
+                preferDealMethods && preferDealMethods.includes('全家')
               }
             >
               {familyMart}
             </TransactionType>
             <TransactionType
               $isSelected={
-                preferDealMethods &&
-                preferDealMethods.convenientStores &&
-                preferDealMethods.convenientStores.includes('7-11')
+                preferDealMethods && preferDealMethods.includes('7-11')
               }
             >
               {sevenEleven}
             </TransactionType>
             <TransactionType
-              $isSelected={preferDealMethods && preferDealMethods.faceToFace}
+              $isSelected={
+                preferDealMethods && preferDealMethods.includes('面交')
+              }
             >
               {faceToFace}
             </TransactionType>


### PR DESCRIPTION
主要修改後台的管理問答頁
 - 將新增、編輯彈窗的 UI 與資料處理分離
 - 將新增的問答項目加到最後，並且頁面跳到最後一頁
 - 最後一頁刪到沒有問答時，自動回到第一頁
 - 換頁時視窗回到頂端
 
其他修改的部分
- 登入頁、註冊頁權限， 讓已登入的使用者跳回首頁
- 個人主頁中，偏好交易方式的資料設定
- 交易紀錄頁中，使用者沒有交易紀錄的狀況